### PR TITLE
[enh] support_a_lot_of_aliens

### DIFF
--- a/include/space_invaders_game_state.h
+++ b/include/space_invaders_game_state.h
@@ -22,18 +22,18 @@ struct game_state {
   struct cexil_text text_score;
   struct cexil_text text_level;
 
-  int score;
-  int total_score;
+  long long int score;
+  long long int total_score;
 
   unsigned long long int total_time;
 
   struct player player;
 
   struct alien** aliens;
-  unsigned short int aliens_count;
+  unsigned long long int aliens_count;
 
-  unsigned char aliens_rows;
-  unsigned char aliens_columns;
+  unsigned long long int aliens_rows;
+  unsigned long long int aliens_columns;
 
   struct math_c_vector2_int aliens_position;
 
@@ -42,15 +42,15 @@ struct game_state {
   struct velocity aliens_velocity;
 
   struct cexil_timer timer;
-  unsigned int level;
+  unsigned long long int level;
 
   struct cexil_renderer* renderer;
 
   struct projectile** projectiles_player;
   struct projectile** projectiles_alien;
 
-  unsigned short int projectiles_player_count;
-  unsigned short int projectiles_alien_count;
+  unsigned long long int projectiles_player_count;
+  unsigned long long int projectiles_alien_count;
 };
 
 void game_state_initialize_with_mode(
@@ -107,7 +107,7 @@ void game_state_totals_set(
 
 void game_state_alien_remove(
   struct game_state*,
-  unsigned short int index_alien
+  unsigned long long int index_alien
 );
 
 void game_state_aliens_remove_all(
@@ -118,7 +118,7 @@ void game_state_projectile_add(
   struct game_state* game_state,
   struct projectile* projectile,
   struct projectile*** projectiles,
-  unsigned short int* projectiles_count
+  unsigned long long int* projectiles_count
 );
 
 void game_state_projectile_player_add(
@@ -134,24 +134,24 @@ void game_state_projectile_alien_add(
 void game_state_projectile_remove(
   struct game_state*,
   struct projectile***,
-  unsigned short int,
-  unsigned short int*
+  unsigned long long int,
+  unsigned long long int*
 );
 
 void game_state_projectile_player_remove(
   struct game_state*,
-  unsigned short int
+  unsigned long long int
 );
 
 void game_state_projectile_alien_remove(
   struct game_state*,
-  unsigned short int
+  unsigned long long int
 );
 
 void game_state_projectiles_remove_all(
   struct game_state*,
   struct projectile***,
-  unsigned short int*
+  unsigned long long int*
 );
 
 void game_state_projectiles_alien_remove_all(

--- a/sources/space_invaders.c
+++ b/sources/space_invaders.c
@@ -9,6 +9,7 @@
 
 #include <interrupt_handler.h>
 
+#include <math_c_maximum.h>
 #include <math_c_vector.h>
 
 #include <stdio.h>
@@ -164,6 +165,39 @@ int main(
     &game_state,
     &renderer
   );
+  
+  if (
+    space_invaders_parameters &
+    space_invaders_parameter_fill_screen
+  ) {
+    game_state.aliens_columns = (
+      math_c_maximum_unsigned_int(
+        (
+          size_renderer.x /
+          (
+            alien_size_width +
+            alien_spacing_x
+          ) -
+          0x04
+        ),
+        0x01
+      )
+    );
+    
+    game_state.aliens_rows = (
+      math_c_maximum_unsigned_int(
+        (
+          size_renderer.y /
+          (
+            alien_size_height +
+            alien_spacing_y
+          ) /
+          0x02
+        ),
+        0x01
+      )
+    );
+  }
 
   if (
     space_invaders_parameters &
@@ -222,9 +256,9 @@ int main(
   
     printf(
       "game_over\n\n"
-      "total_score->{%i}\n"
+      "total_score->{%lli}\n"
       "total_time->{%llu_seconds}\n"
-      "level->{%u}\n"
+      "level->{%llu}\n"
       "\n",
       game_state.total_score,
       (

--- a/sources/space_invaders_game_state.c
+++ b/sources/space_invaders_game_state.c
@@ -362,7 +362,7 @@ void game_state_aliens_populate(
   );
 
   for (
-    unsigned char y_index = (
+    unsigned long long int y_index = (
       0x00
     );
     (
@@ -371,13 +371,13 @@ void game_state_aliens_populate(
     );
     ++y_index
   ) {
-    unsigned char y_offset = (
+    unsigned long long int y_offset = (
       y_index *
       game_state->aliens_columns
     );
 
     for (
-      unsigned char x_index = (
+      unsigned long long int x_index = (
         0x00
       );
       (
@@ -386,7 +386,7 @@ void game_state_aliens_populate(
       );
       ++x_index
     ) {
-      unsigned char index_alien = (
+      unsigned long long int index_alien = (
         y_offset +
         x_index
       );
@@ -496,11 +496,11 @@ void game_state_progress_level(
 void game_state_text_score_set(
   struct game_state* game_state
 ) {
-  int score = (
+  long long int score = (
     game_state->score
   );
 
-  unsigned short int score_length;
+  unsigned long long int score_length;
 
   if (
     score <
@@ -566,7 +566,7 @@ void game_state_text_score_set(
   }
 
   for (
-    unsigned short int index_score = (
+    unsigned long long int index_score = (
       0x00
     );
     (
@@ -632,11 +632,11 @@ void game_state_text_score_set(
 void game_state_text_level_set(
   struct game_state* game_state
 ) {
-  int level = (
+  unsigned long long int level = (
     game_state->level
   );
 
-  unsigned short int level_length = (
+  unsigned long long int level_length = (
     0x01
   );
 
@@ -650,7 +650,7 @@ void game_state_text_level_set(
     level >=
     0x00
   ) {
-    unsigned int level_part = (
+    unsigned long long int level_part = (
       level /
       0x0a
     );
@@ -688,7 +688,7 @@ void game_state_text_level_set(
   }
 
   for (
-    unsigned short int index_level = (
+    unsigned long long int index_level = (
       0x00
     );
     (
@@ -816,7 +816,7 @@ void game_state_poll_game(
   }
 
   for (
-    long int index_projectile_player = (
+    unsigned long long int index_projectile_player = (
       0x00
     );
     (
@@ -851,7 +851,7 @@ void game_state_poll_game(
     }
 
     for (
-      long int index_alien = (
+      unsigned long long int index_alien = (
         0x00
       );
       (
@@ -906,7 +906,7 @@ void game_state_poll_game(
   }
 
   for (
-    unsigned int index_projectile_alien = (
+    unsigned long long int index_projectile_alien = (
       0x00
     );
     (
@@ -1054,7 +1054,7 @@ void game_state_poll_game(
   }
 
   for (
-    long int index_alien = (
+    unsigned long long int index_alien = (
       0x00
     );
     (
@@ -1217,7 +1217,7 @@ void game_state_poll(
 
 void game_state_alien_remove(
   struct game_state* game_state,
-  unsigned short int index_alien
+  unsigned long long int index_alien
 ) {
   cexil_renderer_sprite_remove(
     game_state->renderer,
@@ -1247,7 +1247,7 @@ void game_state_alien_remove(
   );
 
   for (
-    long int index_remaining_alien = (
+    unsigned long long int index_remaining_alien = (
       index_alien
     );
     (
@@ -1288,7 +1288,7 @@ void game_state_aliens_remove_all(
   }
 
   for (
-    unsigned short int index_alien = (
+    unsigned long long int index_alien = (
       game_state->aliens_count
     );
     (
@@ -1311,7 +1311,7 @@ void game_state_projectile_add(
   struct game_state* game_state,
   struct projectile* projectile,
   struct projectile*** projectiles,
-  unsigned short int* projectiles_count
+  unsigned long long int* projectiles_count
 ) {
   *projectiles_count = (
     *projectiles_count +
@@ -1368,8 +1368,8 @@ void game_state_projectile_player_add(
 void game_state_projectile_remove(
   struct game_state* game_state,
   struct projectile*** projectiles,
-  unsigned short int index_projectile,
-  unsigned short int* projectiles_count
+  unsigned long long int index_projectile,
+  unsigned long long int* projectiles_count
 ) {
   cexil_renderer_sprite_remove(
     game_state->renderer,
@@ -1392,7 +1392,7 @@ void game_state_projectile_remove(
   );
 
   for (
-    long int index_remaining_projectile = (
+    unsigned long long int index_remaining_projectile = (
       index_projectile
     );
     (
@@ -1424,7 +1424,7 @@ void game_state_projectile_remove(
 
 void game_state_projectile_alien_remove(
   struct game_state* game_state,
-  unsigned short int index_projectile
+  unsigned long long int index_projectile
 ) {
   game_state_projectile_remove(
     game_state,
@@ -1436,7 +1436,7 @@ void game_state_projectile_alien_remove(
 
 void game_state_projectile_player_remove(
   struct game_state* game_state,
-  unsigned short int index_projectile
+  unsigned long long int index_projectile
 ) {
   game_state_projectile_remove(
     game_state,
@@ -1449,10 +1449,10 @@ void game_state_projectile_player_remove(
 void game_state_projectiles_remove_all(
   struct game_state* game_state,
   struct projectile*** projectiles,
-  unsigned short int* projectiles_count
+  unsigned long long int* projectiles_count
 ) {
   for (
-    unsigned int index_projectile = (
+    unsigned long long int index_projectile = (
       *projectiles_count
     );
     (
@@ -1497,7 +1497,7 @@ void game_state_destroy(
   struct game_state* game_state
 ) {
   for (
-    unsigned int index_projectile_player = (
+    unsigned long long int index_projectile_player = (
       0x00
     );
     (
@@ -1514,7 +1514,7 @@ void game_state_destroy(
   }
 
   for (
-    unsigned int index_projectile_alien = (
+    unsigned long long int index_projectile_alien = (
       0x00
     );
     (
@@ -1532,7 +1532,7 @@ void game_state_destroy(
   }
 
   for (
-    unsigned int index_alien = (
+    unsigned long long int index_alien = (
       0x00
     );
     (


### PR DESCRIPTION
- `fill_screen`
- - now adds columns/rows based on the size of the screen


https://github.com/user-attachments/assets/5c7ac6e6-498e-44ab-81a3-c0833cb8b616

<img width="2880" height="1806" alt="Screenshot 2026-05-11 at 17 13 54" src="https://github.com/user-attachments/assets/e8067268-5b37-47d2-b836-b6e7d721985d" />
<img width="2880" height="1806" alt="Screenshot 2026-05-11 at 17 14 13" src="https://github.com/user-attachments/assets/a45d8f59-815d-4b43-8fe4-f7377500507e" />
<img width="2880" height="1806" alt="Screenshot 2026-05-11 at 17 14 27" src="https://github.com/user-attachments/assets/31e3a008-0550-4584-8087-8f61c45a32a8" />

technically still limited by the memory allocation functions being typed as `int` for the parameters, something i will support at a later point int time.