### PR TITLE
[bug] `space_invaders_audio`:prevent_division_by_zero

### DIFF
--- a/sources/space_invaders_audio.c
+++ b/sources/space_invaders_audio.c
@@ -195,11 +195,16 @@ int space_invaders_audio_output_io_proc(
           }
         }
         
-        value = (
-          value /
-          (float)
-          active_synthesizers
-        );
+        if (
+          active_synthesizers >
+          0x00
+        ) {
+          value = (
+            value /
+            (float)
+            active_synthesizers
+          );
+        }
       
         pthread_mutex_unlock(
           &game_state->audio.mutex


### PR DESCRIPTION
- `space_invaders_audio`:prevent_division_by_zero
- - fixes audio not outputing
- - - why this worked before the fix when using airpods but not the speakers i have no idea